### PR TITLE
fix: not working on 1.16.2

### DIFF
--- a/plugin/emoji.py
+++ b/plugin/emoji.py
@@ -1,6 +1,7 @@
 import webbrowser
 from pathlib import Path
 import json
+import sys
 from subprocess import Popen, PIPE
 from time import sleep
 
@@ -100,18 +101,9 @@ class Emoji(Flox, Clipboard):
         """
         script_path = Path(__file__).parent.resolve() / "sendkeys.py"
         self.copy_emoji(char)
-        python_path = 'pythonw.exe'
-        python_setting = self.app_settings["PluginSettings"].get("PythonDirectory")
-        if python_setting:
-            python_path = Path(python_setting, "python.exe")
-        else:
-            python_executable_path = Path(self.app_settings["PluginSettings"].get("PythonExecutablePath"))
-            python_path = python_executable_path.parent / 'pythonw.exe'
-        Popen([python_path, script_path], creationflags=NO_WINDOW)
+        Popen([sys.executable, script_path], creationflags=NO_WINDOW)
         self.close_app()
-
 
 
 if __name__ == "__main__":
     Emoji()
-

--- a/plugin/emoji.py
+++ b/plugin/emoji.py
@@ -101,9 +101,12 @@ class Emoji(Flox, Clipboard):
         script_path = Path(__file__).parent.resolve() / "sendkeys.py"
         self.copy_emoji(char)
         python_path = 'pythonw.exe'
-        python_setting = Path(self.app_settings["PluginSettings"].get("PythonDirectory"))
+        python_setting = self.app_settings["PluginSettings"].get("PythonDirectory")
         if python_setting:
             python_path = Path(python_setting, "python.exe")
+        else:
+            python_executable_path = Path(self.app_settings["PluginSettings"].get("PythonExecutablePath"))
+            python_path = python_executable_path.parent / 'pythonw.exe'
         Popen([python_path, script_path], creationflags=NO_WINDOW)
         self.close_app()
 

--- a/run.py
+++ b/run.py
@@ -2,9 +2,9 @@ import sys
 import os
 
 plugindir = os.path.abspath(os.path.dirname(__file__))
-sys.path.append(plugindir)
-sys.path.append(os.path.join(plugindir, "lib"))
-sys.path.append(os.path.join(plugindir, "plugin"))
+sys.path.insert(0, plugindir)
+sys.path.insert(0, os.path.join(plugindir, "lib"))
+sys.path.insert(0, os.path.join(plugindir, "plugin"))
 
 from plugin.emoji import Emoji
 


### PR DESCRIPTION
1. `PythonDirectory` does not exist on my local machine with Flow Launcher v1.16.2
![image](https://github.com/Garulf/Emoji-plus/assets/61080/cb8cdb0f-0671-44da-82b8-240b57c60d2c)
2. Prepend the local `lib` path instead of appending in case there was an older `flox` from the system packages